### PR TITLE
Add diagnostic output

### DIFF
--- a/nodes/cbw_x4xx_node.py
+++ b/nodes/cbw_x4xx_node.py
@@ -234,7 +234,7 @@ def publish_common_values(publisher, diag_pub, values):
     ds.hardware_id = 'ben'
     diag_array = DiagnosticArray()
     diag_array.header.stamp = rospy.Time.now()
-    ds.name = 'ben'
+    ds.name = 'cbw'
 
     # frame values
     if 'vin' in values:

--- a/nodes/cbw_x4xx_node.py
+++ b/nodes/cbw_x4xx_node.py
@@ -231,7 +231,7 @@ def publish_common_values(publisher, diag_pub, values):
 
     # establish diag msg
     ds = DiagnosticStatus()
-    ds.hardware_id = 'ben'
+    ds.hardware_id = '00:0C:C8:04:41:8C'
     diag_array = DiagnosticArray()
     diag_array.header.stamp = rospy.Time.now()
     ds.name = 'cbw'

--- a/nodes/cbw_x4xx_node.py
+++ b/nodes/cbw_x4xx_node.py
@@ -231,7 +231,6 @@ def publish_common_values(publisher, diag_pub, values):
 
     # establish diag msg
     ds = DiagnosticStatus()
-    ds.hardware_id = '00:0C:C8:04:41:8C'
     diag_array = DiagnosticArray()
     diag_array.header.stamp = rospy.Time.now()
     ds.name = 'cbw'
@@ -245,7 +244,7 @@ def publish_common_values(publisher, diag_pub, values):
     
     if 'serialNumber' in values:
         status.serial_number = values['serialNumber']
-        ds.values.append(KeyValue('serialNumber', values['serialNumber']))
+        ds.hardware_id = values['serialNumber']
     else:
         status.serial_number = "unknown"
     


### PR DESCRIPTION
This change simply adds diagnostic msg output using the existing structure of the cbw monitoring node, it publishes alongside the original cbw topics and using the same parsed output.